### PR TITLE
Fix `clear()` method return value

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ class YoctoSpinner {
 
 	clear() {
 		if (!this.#isInteractive) {
-			return;
+			return this;
 		}
 
 		this.#stream.cursorTo(0);
@@ -157,6 +157,8 @@ class YoctoSpinner {
 		}
 
 		this.#lines = 0;
+
+		return this;
 	}
 
 	#render() {


### PR DESCRIPTION
Hello,

While the documentation mentions that the `clear()` method returns the instance, it doesn't actually do so. This causes an error when attempting to use method chaining, as shown in the example below:

```js
spinner.clear().stop();
```

To fix this, I modified the `clear()` method to return `this`, enabling method chaining. I also followed the formatting style used in the `start()` and `stop()` methods.

- For reference, here is the formatting used in the `start()` and `stop()` methods:  
    https://github.com/sindresorhus/yocto-spinner/blob/4e18542b8cd4e589a01527dba9f97419316006c5/index.js#L64-L100

- I’ve also attached a screenshot of the documentation for reference:  
  ![image](https://github.com/user-attachments/assets/60ff95fb-adbf-4fb3-aa95-37a64e19ff9d)
