### PR TITLE
Improve line break handling when using ANSI escapes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import process from 'node:process';
+import {stripVTControlCharacters} from 'node:util';
 import yoctocolors from 'yoctocolors';
 
 const isUnicodeSupported = process.platform !== 'win32' || Boolean(process.env.WT_SESSION);
@@ -192,7 +193,7 @@ class YoctoSpinner {
 
 	#lineCount(text) {
 		const width = this.#stream.columns ?? 80;
-		const lines = text.split('\n');
+		const lines = stripVTControlCharacters(text).split('\n');
 
 		let lineCount = 0;
 		for (const line of lines) {


### PR DESCRIPTION
I understand not using strip-ansi and string-width like ora to keep the package size small, but stripVTControlCharacters has been in Node.js since version 16 and it seems to work just as well.

Possibly a similar PR would be good for ora to replace those dependencies, but I'm unsure if strip-ansi and string-width have some advantage over stripVTControlCharacters. Regardless, stripVTControlCharacters does seem like a clear win over nothing!