### PR TITLE
fix: ensure default value is correctly applied in setter

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,8 +128,8 @@ class YoctoSpinner {
 		return this.#text;
 	}
 
-	set text(value = '') {
-		this.#text = value;
+	set text(value) {
+		this.#text = value ?? '';
 		this.#render();
 	}
 


### PR DESCRIPTION
Hello, This PR fixes an issue where the default value was not being applied correctly in the `text` setter.  

### Changes:
- Removed the default parameter value (`value = ''`) from the setter method.  
- Implemented `value ?? ''` inside the setter to ensure that `undefined` or `null` is replaced with an empty string (`''`).  

### Why this change?
![image](https://github.com/user-attachments/assets/d1eaf141-5264-4574-92f6-a94760c9e7f6)
- In JavaScript, setter functions do not support default parameter values in a meaningful way because they are always called with an explicit argument when assigning a value.  
- Previously, setting `obj.text = undefined;` would assign `undefined` instead of an empty string, which is likely unintended behavior.  
- Using `value ?? ''` ensures that `undefined` or `null` is replaced with `''`, making the behavior more predictable.  

### Impact:
- This change ensures consistent handling of `undefined` and `null` values when setting the `text` property.  
- No breaking changes are expected, as explicit assignments will continue to work as before.  

Let me know if any further improvements are needed!