### PR TITLE
yoctocolors -> styleText, drop support for Node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 24
           - 22
           - 20
-          - 18
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 import process from 'node:process';
-import {stripVTControlCharacters} from 'node:util';
-import yoctocolors from 'yoctocolors';
+import {inspect, stripVTControlCharacters, styleText} from 'node:util';
 
 const isUnicodeSupported = process.platform !== 'win32'
 	|| Boolean(process.env.WT_SESSION) // Windows Terminal
@@ -12,10 +11,10 @@ const isInteractive = stream => Boolean(
 	&& !('CI' in process.env),
 );
 
-const infoSymbol = yoctocolors.blue(isUnicodeSupported ? 'ℹ' : 'i');
-const successSymbol = yoctocolors.green(isUnicodeSupported ? '✔' : '√');
-const warningSymbol = yoctocolors.yellow(isUnicodeSupported ? '⚠' : '‼');
-const errorSymbol = yoctocolors.red(isUnicodeSupported ? '✖' : '×');
+const infoSymbol = styleText('blue', isUnicodeSupported ? 'ℹ' : 'i');
+const successSymbol = styleText('green', isUnicodeSupported ? '✔' : '√');
+const warningSymbol = styleText('yellow', isUnicodeSupported ? '⚠' : '‼');
+const errorSymbol = styleText('red', isUnicodeSupported ? '✖' : '×');
 
 const defaultSpinner = {
 	frames: isUnicodeSupported
@@ -182,9 +181,9 @@ class YoctoSpinner {
 			this.#lastSpinnerFrameTime = now;
 		}
 
-		const applyColor = yoctocolors[this.#color] ?? yoctocolors.cyan;
+		const color = inspect.colors[this.#color] ? this.#color : 'cyan';
 		const frame = this.#frames[this.#currentFrame];
-		let string = `${applyColor(frame)} ${this.#text}`;
+		let string = `${styleText(color, frame)} ${this.#text}`;
 
 		if (!this.#isInteractive) {
 			string += '\n';

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=18.19"
+		"node": ">=20.12.0 <21 || >=21.7.0"
 	},
 	"scripts": {
 		"test": "xo && ava && tsc index.d.ts"
@@ -46,9 +46,6 @@
 		"micro",
 		"nano"
 	],
-	"dependencies": {
-		"yoctocolors": "^2.1.1"
-	},
 	"devDependencies": {
 		"ava": "^6.1.3",
 		"typescript": "^5.5.4",

--- a/test.js
+++ b/test.js
@@ -1,10 +1,10 @@
 import {setTimeout as delay} from 'node:timers/promises';
 import process from 'node:process';
 import {PassThrough} from 'node:stream';
+import {styleText} from 'node:util';
 import getStream from 'get-stream';
 import test from 'ava';
 import stripAnsi from 'strip-ansi';
-import yoctocolors from 'yoctocolors';
 import yoctoSpinner from './index.js';
 
 delete process.env.CI;
@@ -155,7 +155,7 @@ test('spinner accounts for ANSI escape codes when computing line breaks', async 
 
 		let text = '';
 		for (let i = 0; i < scenario.textLength; i++) {
-			text += yoctocolors.blue('a');
+			text += styleText('blue', 'a');
 		}
 
 		// eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
This decreases package size a bit by using the built-in styleText rather than yoctocolors (which would then mean that yocto-spinner has no dependencies!). Also requires dropping Node 18 support.