### PR TITLE
fix: only can use foreground colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ class YoctoSpinner {
 	#timer;
 	#text;
 	#stream;
-	#color;
+	#color = 'cyan';
 	#lines = 0;
 	#exitHandlerBound;
 	#isInteractive;
@@ -60,7 +60,7 @@ class YoctoSpinner {
 		this.#interval = spinner.interval;
 		this.#text = options.text ?? '';
 		this.#stream = options.stream ?? process.stderr;
-		this.#color = options.color ?? 'cyan';
+		this.#color = this.#useColor(options.color);
 		this.#isInteractive = isInteractive(this.#stream);
 		this.#exitHandlerBound = this.#exitHandler.bind(this);
 	}
@@ -149,7 +149,7 @@ class YoctoSpinner {
 	}
 
 	set color(value) {
-		this.#color = value;
+		this.#color = this.#useColor(value);
 		this.#render();
 	}
 
@@ -245,6 +245,15 @@ class YoctoSpinner {
 		// SIGTERM: 128 + 15
 		const exitCode = signal === 'SIGINT' ? 130 : (signal === 'SIGTERM' ? 143 : 1);
 		process.exit(exitCode);
+	}
+
+	#useColor(name) {
+		if (['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'gray'].includes(name)) {
+			return name;
+		}
+
+		// Use current spinner color
+		return this.#color;
 	}
 }
 

--- a/test.js
+++ b/test.js
@@ -203,3 +203,95 @@ test('spinner in non-interactive mode only renders on text changes', async t => 
 	t.is(lines[1], '- changed text');
 	t.is(lines[2], 'final text');
 });
+
+// eslint-disable-next-line no-control-regex -- This is right?
+const nonSgrRe = /\u001B(?!\[\d+?m)/g;
+
+test('Use default color (cyan) if color option is NOT provided', async t => {
+	const stream = getPassThroughStream();
+	stream.isTTY = false;
+
+	const output = getStream(stream);
+
+	const spinner = yoctoSpinner({
+		stream,
+		text: 'initial text',
+		spinner: {
+			frames: ['-'],
+			interval: 10,
+		},
+	});
+
+	spinner.start();
+
+	await delay(50);
+
+	spinner.stop();
+	stream.end();
+
+	const out = await output;
+	// eslint-disable-next-line unicorn/prefer-string-replace-all -- Strip Non-SGR
+	const result = out.replace(nonSgrRe, '').trim();
+
+	t.is(result, `${yoctocolors.cyan('-')} initial text`);
+});
+
+test('Use default color (cyan) if color option is NOT use foreground colors', async t => {
+	const stream = getPassThroughStream();
+	stream.isTTY = false;
+
+	const output = getStream(stream);
+
+	const spinner = yoctoSpinner({
+		stream,
+		text: 'initial text',
+		spinner: {
+			frames: ['-'],
+			interval: 10,
+		},
+		color: 'bgBlue',
+	});
+
+	spinner.start();
+
+	await delay(50);
+
+	spinner.stop();
+	stream.end();
+
+	const out = await output;
+	// eslint-disable-next-line unicorn/prefer-string-replace-all -- Strip Non-SGR
+	const result = out.replace(nonSgrRe, '').trim();
+
+	t.is(result, `${yoctocolors.cyan('-')} initial text`);
+});
+
+test('Can use custum color', async t => {
+	const stream = getPassThroughStream();
+	stream.isTTY = false;
+
+	const output = getStream(stream);
+
+	const spinner = yoctoSpinner({
+		stream,
+		text: 'initial text',
+		spinner: {
+			frames: ['-'],
+			interval: 10,
+		},
+		color: 'green',
+	});
+
+	spinner.start();
+
+	await delay(50);
+
+	spinner.stop();
+	stream.end();
+
+	const out = await output;
+	// eslint-disable-next-line unicorn/prefer-string-replace-all -- Strip Non-SGR
+	const result = out.replace(nonSgrRe, '').trim();
+
+	t.is(result, `${yoctocolors.green('-')} initial text`);
+});


### PR DESCRIPTION
Make spinner only can use foreground colors like we define in types file.

example:
```js
import yoctoSpinner from './index.js';

const spinner = yoctoSpinner({
    text: 'Loading unicorns\n  (And rainbows)',
    // Not a foreground color, so we use default (cyan)
    color: 'bgYellow'
}).start();

setTimeout(() => {
    // A foreground color, change the spinner color
    spinner.color = 'red';
    spinner.text = 'Calculating splines';
}, 2000);

setTimeout(() => {
    spinner.success('Finished!');
}, 5000);

```

