### PR TITLE
Add handleSignals option to disable process signal handlers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,15 @@ export type Options = {
 	@default process.stderr
 	*/
 	readonly stream?: Writable;
+
+	/**
+	Whether to handle `SIGINT` and `SIGTERM` by stopping the spinner and exiting the process.
+
+	Disable this when the application needs to manage process signals itself.
+
+	@default true
+	*/
+	readonly handleSignals?: boolean;
 };
 
 export type Spinner = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,9 +53,9 @@ export type Options = {
 	readonly stream?: Writable;
 
 	/**
-	Whether to handle `SIGINT` and `SIGTERM` by stopping the spinner and exiting the process.
+	Whether to register `SIGINT` and `SIGTERM` listeners that stop the spinner and explicitly exit the process.
 
-	Disable this when the application needs to manage process signals itself.
+	Disable this when the application needs to manage those signals itself.
 
 	@default true
 	*/

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ class YoctoSpinner {
 
 		this.#frames = spinner.frames;
 		this.#interval = spinner.interval ?? defaultSpinner.interval;
-		this.#handleSignals = options.handleSignals ?? true;
+		this.#handleSignals = options.handleSignals ?? true; // SOMEDAY: Remove this option if Node.js ever adds passive signal listeners: https://github.com/nodejs/node/issues/62909
 		this.#text = options.text ?? '';
 		this.#stream = options.stream ?? process.stderr;
 		this.#color = options.color ?? 'cyan';

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ class YoctoSpinner {
 	#interval;
 	#currentFrame = -1;
 	#timer;
+	#handleSignals;
 	#text;
 	#stream;
 	#color;
@@ -75,6 +76,7 @@ class YoctoSpinner {
 
 		this.#frames = spinner.frames;
 		this.#interval = spinner.interval ?? defaultSpinner.interval;
+		this.#handleSignals = options.handleSignals ?? true;
 		this.#text = options.text ?? '';
 		this.#stream = options.stream ?? process.stderr;
 		this.#color = options.color ?? 'cyan';
@@ -392,11 +394,19 @@ class YoctoSpinner {
 	}
 
 	#subscribeToProcessEvents() {
+		if (!this.#handleSignals) {
+			return;
+		}
+
 		process.once('SIGINT', this.#exitHandlerBound);
 		process.once('SIGTERM', this.#exitHandlerBound);
 	}
 
 	#unsubscribeFromProcessEvents() {
+		if (!this.#handleSignals) {
+			return;
+		}
+
 		process.off('SIGINT', this.#exitHandlerBound);
 		process.off('SIGTERM', this.#exitHandlerBound);
 	}

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,15 @@ Default: `process.stderr`
 
 The stream to which the spinner is written.
 
+##### handleSignals
+
+Type: `boolean`\
+Default: `true`
+
+Whether to handle `SIGINT` and `SIGTERM` by stopping the spinner and exiting the process.
+
+Disable this when the application needs to manage process signals itself.
+
 ### Instance methods
 
 #### .start(text?)

--- a/readme.md
+++ b/readme.md
@@ -101,9 +101,9 @@ The stream to which the spinner is written.
 Type: `boolean`\
 Default: `true`
 
-Whether to handle `SIGINT` and `SIGTERM` by stopping the spinner and exiting the process.
+Whether to register `SIGINT` and `SIGTERM` listeners that stop the spinner and explicitly exit the process.
 
-Disable this when the application needs to manage process signals itself.
+Disable this when the application needs to manage those signals itself.
 
 ### Instance methods
 

--- a/test.js
+++ b/test.js
@@ -107,6 +107,46 @@ test('spinner does not hook non-interactive streams', t => {
 	t.is(stream.write, originalWrite);
 });
 
+test('spinner subscribes to process signals by default', t => {
+	const initialSigintCount = process.rawListeners('SIGINT').length;
+	const initialSigtermCount = process.rawListeners('SIGTERM').length;
+
+	const stream = getPassThroughStream();
+	const spinner = yoctoSpinner({stream, text: 'foo'});
+
+	spinner.start();
+
+	t.is(process.rawListeners('SIGINT').length, initialSigintCount + 1);
+	t.is(process.rawListeners('SIGTERM').length, initialSigtermCount + 1);
+
+	spinner.stop();
+
+	t.is(process.rawListeners('SIGINT').length, initialSigintCount);
+	t.is(process.rawListeners('SIGTERM').length, initialSigtermCount);
+});
+
+test('spinner can disable process signal handling', t => {
+	const initialSigintCount = process.rawListeners('SIGINT').length;
+	const initialSigtermCount = process.rawListeners('SIGTERM').length;
+
+	const stream = getPassThroughStream();
+	const spinner = yoctoSpinner({
+		stream,
+		text: 'foo',
+		handleSignals: false,
+	});
+
+	spinner.start();
+
+	t.is(process.rawListeners('SIGINT').length, initialSigintCount);
+	t.is(process.rawListeners('SIGTERM').length, initialSigtermCount);
+
+	spinner.stop();
+
+	t.is(process.rawListeners('SIGINT').length, initialSigintCount);
+	t.is(process.rawListeners('SIGTERM').length, initialSigtermCount);
+});
+
 test('spinner starts with custom text', async t => {
 	const output = await runSpinner(spinner => spinner.stop(), {text: 'custom'});
 	t.is(output, '- custom\n');


### PR DESCRIPTION
This adds a `handleSignals` option to `yocto-spinner`.

By default, the current behavior is unchanged: when a spinner is active, it subscribes to `SIGINT` and `SIGTERM`, stops the spinner, and exits the process.

When `handleSignals: false` is passed, the spinner no longer subscribes to those process-level signal handlers. This is useful for applications that embed `yocto-spinner` but need to manage process signals themselves.

### Changes

- Add `handleSignals?: boolean` to the public options type.
- Default `handleSignals` to `true` to preserve existing behavior.
- Skip subscribing and unsubscribing `SIGINT` / `SIGTERM` handlers when `handleSignals` is `false`.
- Document the new option in the README.
- Add tests covering the default behavior and the opt-out behavior.

Verified `npm test` locally.