### PR TITLE
Fix infinite loop when the stream is a TTY with columns of 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -374,7 +374,7 @@ class YoctoSpinner {
 	}
 
 	#lineCount(text) {
-		const width = this.#stream.columns ?? 80;
+		const width = this.#stream.columns || 80; // `columns` can be 0
 		const lines = stripVTControlCharacters(text.replaceAll(oscSequenceRegex, '')).split('\n');
 
 		let lineCount = 0;

--- a/test.js
+++ b/test.js
@@ -272,6 +272,26 @@ test('spinner counts lines correctly for hyperlinks with special URI characters'
 	t.is(clearLineCount, 1);
 });
 
+test('spinner does not loop forever when the stream reports zero columns', async t => {
+	let clearLineCount = 0;
+
+	const stream = new PassThrough();
+	stream.clearLine = () => {
+		clearLineCount += 1;
+	};
+
+	stream.cursorTo = () => {};
+	stream.moveCursor = () => {};
+	stream.isTTY = true;
+	stream.columns = 0;
+
+	await runSpinner(spinner => spinner.stop(), {}, {
+		stream,
+	});
+
+	t.is(clearLineCount, 1);
+});
+
 test('spinner in non-interactive mode only renders on text changes', async t => {
 	const stream = getPassThroughStream();
 	stream.isTTY = false;


### PR DESCRIPTION
There is a bug where an infinite loop occurs when the TTY width is 0. This is mainly reproducible via `script` run in a non-terminal context, which attaches a width-0 TTY to its child. For example, the Bash tool of coding agents runs in a non-terminal context. I found this issue while trying to inspect the escape sequences emitted by the spinner in a coding agent.

```javascript
import yoctoSpinner from "yocto-spinner";

const spinner = yoctoSpinner({ text: "text" }).start();
setTimeout(() => spinner.stop(), 2000);
```

Since the log is written to rapidly and consumes disk space, run the reproduction under something like `timeout 5`.

```
$ script --command 'node tty-test.js' /tmp/out.log  </dev/null 2>&1 | cat

or let Claude Code execute:
Bash(script --command 'node tty-test.js' /tmp/out.log)
```
